### PR TITLE
Update to ITSxpress

### DIFF
--- a/recipes/itsxpress/meta.yaml
+++ b/recipes/itsxpress/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - biopython >=1.60
     - hmmer >=3.1b2
     - bbmap
-    - vsearch
+    - vsearch=2.7.0
 
 test:
   imports:


### PR DESCRIPTION
Versioned Vsearch to fix breaking change in API of fulllength-rerep in vsearch 2.20.


